### PR TITLE
Upgraded to .NET 9 and resolved breaking changes.

### DIFF
--- a/BlazorSQLiteWasm.csproj
+++ b/BlazorSQLiteWasm.csproj
@@ -1,22 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
-
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <WasmBuildNative>true</WasmBuildNative>
-
     <!-- workaround for publish -->
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EmccExtraLDFlags>-s WARN_ON_UNDEFINED_SYMBOLS=0</EmccExtraLDFlags>
   </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="6.0.1" PrivateAssets="all" />
-    <PackageReference Include="System.Net.Http.Json" Version="6.0.0" />
-
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.1" PrivateAssets="all" />
+    <PackageReference Include="System.Net.Http.Json" Version="9.0.1" />
     <!-- EF Core and Sqlite -->
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.1" />
-    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.0-pre20220207221914" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.1" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.10" />
   </ItemGroup>
-
 </Project>

--- a/README.md
+++ b/README.md
@@ -8,8 +8,16 @@ inside the browser!
 ## Demo
 [BlazorSQLiteWasm](https://trevordarcyevans.github.io/BlazorSQLiteWasm/)
 
+## Changes in this Fork
+This fork addresses issues with the original project:
+* .NET 6 supports the Module object in JS Interop, but .NET 8 and above do not
+* .NET 8 and above use the Blazor.runtime object to provide access to the Mono and Emscripten APIs
+* The Sqlite Nuget had to be updated for .NET 8+ compatibility
+* The Javascript code for syncing the file actually *is** necessary, so I fixed it as well and kept it in
+* More info about the .NET breaking changes can be found here: https://learn.microsoft.com/en-us/dotnet/core/compatibility/aspnet-core/9.0/legacy-apis
+
 ## Prerequisites
-* .NET Core 6
+* .NET Core 8 or 9
 * `wasm-tools` workload
   <details>
   
@@ -21,7 +29,7 @@ inside the browser!
 * Microsoft Visual Studio 2022
 * JetBrains Rider
 * Visual Studio Code
-* Google Chrome
+* Google Chrome or Microsoft Edge
   * should work in other browsers which support wasm
 
 ## Getting Started
@@ -85,7 +93,7 @@ There is some additional code:
 ```
 
 which runs every second.  This is an artefact from the original [BlazeOrbital](https://github.com/SteveSandersonMS/BlazeOrbital)
-project which required the data to be synchronised every second; and is not required for this example.
+project which required the data to be synchronised every second. **This code is actually required otherwise all data can be lost on reload.**
 
 ### SQLite
 _SQLite_ driver is provided by _SQLitePCLRaw.bundle_e_sqlite3_ nuget package and is linked

--- a/wwwroot/dbstorage.js
+++ b/wwwroot/dbstorage.js
@@ -1,30 +1,30 @@
 ﻿export function synchronizeFileWithIndexedDb(filename) {
-  return new Promise((res, rej) => {
-    const db = window.indexedDB.open('SqliteStorage', 1);
-    db.onupgradeneeded = () => {
-      db.result.createObjectStore('Files', { keypath: 'id' });
-    };
+    return new Promise((res, rej) => {
+        const db = window.indexedDB.open('SqliteStorage', 1);
+        db.onupgradeneeded = () => {
+            db.result.createObjectStore('Files', { keypath: 'id' });
+        };
 
-    db.onsuccess = () => {
-      const req = db.result.transaction('Files', 'readonly').objectStore('Files').get('file');
-      req.onsuccess = () => {
-        Module.FS_createDataFile('/', filename, req.result, true, true, true);
-        res();
-      };
-    };
+        db.onsuccess = () => {
+            const req = db.result.transaction('Files', 'readonly').objectStore('Files').get('file');
+            req.onsuccess = () => {
+                Blazor.runtime.Module.FS_createDataFile('/', filename, req.result, true, true, true);
+                res();
+            };
+        };
 
-    let lastModifiedTime = new Date();
-    setInterval(() => {
-      const path = `/${filename}`;
-      if (FS.analyzePath(path).exists) {
-        const mtime = FS.stat(path).mtime;
-        if (mtime.valueOf() !== lastModifiedTime.valueOf()) {
-          lastModifiedTime = mtime;
-          const data = FS.readFile(path);
-          db.result.transaction('Files', 'readwrite').objectStore('Files').put(data, 'file');
-        }
-      }
-    }, 1000);
-  });
+        let lastModifiedTime = new Date();
+        setInterval(() => {
+            const path = `/${filename}`;
+            if (Blazor.runtime.Module.FS.analyzePath(path).exists) {
+                const mtime = Blazor.runtime.Module.FS.stat(path).mtime;
+                if (mtime.valueOf() !== lastModifiedTime.valueOf()) {
+                    lastModifiedTime = mtime;
+                    const data = Blazor.runtime.Module.FS.readFile(path);
+                    db.result.transaction('Files', 'readwrite').objectStore('Files').put(data, 'file');
+                }
+            }
+        }, 1000);
+    });
 }
 


### PR DESCRIPTION
.NET 8 introduced a breaking change causing Emscripten to be located in a different JS object. Originally it was in **Module**. It has since been moved to **Blazor.runtime**.

I've updated the project to reflect this change.

Also, the Javascript code for syncing the file IS necessary, it appears. If the sync check isn't included, refreshing the page causes all changes to be lost.

More details from Microsoft: https://learn.microsoft.com/en-us/dotnet/core/compatibility/aspnet-core/9.0/legacy-apis
